### PR TITLE
Jack review

### DIFF
--- a/sections/00-front.md
+++ b/sections/00-front.md
@@ -48,6 +48,14 @@ organization = "Ribose"
     region = "VA"
     country = "US"
 
+[[author]]
+initials = "J. E."
+surname = "Lloyd"
+fullname = "Jack E. Lloyd"
+organization = "Ribose"
+  [author.address]
+  email = "jack@randombit.net"
+
 area = "Internet"
 workgroup = "Network Working Group"
 date = 2017-08-31T00:00:00Z

--- a/sections/03-sm2.md
+++ b/sections/03-sm2.md
@@ -43,6 +43,13 @@ The SM2DSA algorithm has been cryptanalyzed to a certain extent, with the
 current strongest attack being nonce [@SM2-DSA-Nonces] [@SM2-DSA-Nonces2]
 and lattice attacks [@SM2-DSA-Lattice].
 
+SM2DSA allows use of an optional "user identity" string which is
+hashed into `ZA` (see [@I-D.shen-sm2-ecdsa] section 5.1.4.4). Then the
+hash value `H(ZA || msg)` is signed. For the purposes of PGP
+signatures, the user identifier `IDA` is the empty
+string. Additionally, for usage in PGP, instead of hashing ZA with the
+message itself the hash of the message is used: `H(ZA || H(msg))` where
+both hash algorithms are the same (normally SM3).
 
 ## SM2 Key Exchange Protocol
 

--- a/sections/08-sm2-kdf.md
+++ b/sections/08-sm2-kdf.md
@@ -8,6 +8,9 @@ Section 5.4.3 of [@I-D.shen-sm2-ecdsa], Section 3.4.3 of [@SM2-4]).
 For OSCCA-compliance, it **SHOULD** be used in conjunction with an
 OSCCA-approved hash algorithm, such as SM3 [@!GBT.32905-2016].
 
+The SM2PKE KDF is equivalent to the KDF2 function of IEEE 1363
+[@IEEE-1363], leaving KDF2's label and salt parameters empty.
+
 Pseudocode of the SM2KDF function is provided here for convenience. This
 function contains edited variable names for clarity.
 

--- a/sections/09-encoding.md
+++ b/sections/09-encoding.md
@@ -21,16 +21,6 @@ Algorithm-Specific Fields for SM2DSA keys:
 
 *  MPI of an EC point representing a public key
 
-* a variable-length field containing parameters, formatted as
-  follows:
-
- - a one-octet size of the following fields; values 0 and 0xff are
-   reserved for future extensions
-
- - a one-octet value 01, reserved for future extensions
-
- - a one-octet hash function ID used in the SM2DSA algorithm
-
 Algorithm-Specific Fields for SM2PKE keys:
 
 * a variable-length field containing a curve OID, formatted
@@ -43,19 +33,9 @@ Algorithm-Specific Fields for SM2PKE keys:
 
 *  MPI of an EC point representing a public key
 
-* a variable-length field containing KDF parameters, formatted as
-  follows:
-
- - a one-octet size of the following fields; values 0 and 0xff are
-   reserved for future extensions
-
- - a one-octet value 01, reserved for future extensions
-
- - a one-octet hash function ID used with a KDF
-
-Note that both SM2DSA and SM2PKE public keys are composed of the same sequence
-of fields, but the second, variable-length field is used for different
-purposes.
+Note that both SM2DSA and SM2PKE public keys are composed of the same
+sequence of fields, and use the same codepoint to identify them.
+They are distinguished by the key usage flags.
 
 
 ## Secret-Key Packet Formats

--- a/sections/10-pub-encoding.md
+++ b/sections/10-pub-encoding.md
@@ -7,15 +7,16 @@ Section 5.1 of [RFC4880], "Public-Key Encrypted Session Key Packets
 algorithm specific fields for SM2PKE, through applying the KDF described
 in (#sm2-kdf).
 
-<!-- TODO Jack is this accurate? -->
-
 Algorithm Specific Fields for SM2 encryption:
 
-* MPI of SM2 encrypted value `C = (C1 || C2 || C3)`, described in step A2 of
-  Section 7.2.1. of [@I-D.shen-sm2-ecdsa]
-
-* A one-octet number giving the hash algorithm used for the calculation of
-  `C3`, described in step A7 of Section 7.2.1. of [@I-D.shen-sm2-ecdsa].
+* The SM2 ciphertext is formatted in the PGP bitstream as a single MPI.  This
+  consists of `C = (C1 || C2 || C3)`, described in step A2 of Section 7.2.1. of
+  [@I-D.shen-sm2-ecdsa], followed by a single octet giving the code for the hash
+  algorithm used for the calculation of the KDF mask `t` and `C3`, described in
+  step A5 and A7 of Section 7.2.1. of [@I-D.shen-sm2-ecdsa]. For OSCCA
+  compliance this **MUST** be SM3 or another approved hash and in any case it
+  **SHOULD** be a hash which is listed in the receiving keys "Preferred Hash
+  Algorithms" list.
 
 ## Signature Packet (Tag 2)
 

--- a/sections/97-examples.md
+++ b/sections/97-examples.md
@@ -1,3 +1,23 @@
 # Examples
 
-TODO!
+## Public Key Example
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+xlIEWbGKWmMIKoEcz1UBgi0CAwQx5lUJNwGp01AB7YfAye0oMmyIPYe/cQPVwh8/7RCuywZLMDDA
+M7qn6TNqTtdKW+7tLFhtOC4yzDVK8UjN/ccazSBTTTIgMjU2LWJpdCBrZXkgPGphY2tAbG9jYWxo
+b3N0PsJ0BBNjaQAmBQJZsYpfAhsDBQsJCAcCBhUICQoLAgUWAgMBAAkQC/UcNw0bAZcAAJt5AP4o
+Xvi3xl2RUwAvVjlzXtLL87g6x9cIBS7EB/cvAsw78AEA/Wt6qWlBVZ6TYiqNPt9An/4cjKyNpAv7
+S9u3neGXWUU=
+=RJ3C
+-----END PGP PUBLIC KEY BLOCK-----
+
+## Signature Example
+
+Detached signature of the string "SM2 example" using the above key:
+
+-----BEGIN PGP SIGNATURE-----
+
+wmQEAGMIABYFAlmxj+cFAwAAAAAJEAv1HDcNGwGXAAB+SQEAy5AHKgiRxgOogB/2sfgeJaVoLgpx
+vDp9yIcaLfP++xkBAPGuZ1f9FjxVd5jlCGd1jFzAPpt8N2Lc3FQDqVjgJvV9
+=Xbbj
+-----END PGP SIGNATURE-----

--- a/sections/98-references.md
+++ b/sections/98-references.md
@@ -980,3 +980,13 @@
     <date month='November' year='2001'/>
   </front>
 </reference>
+
+<reference anchor='IEEE.1363' target='http://grouper.ieee.org/groups/1363/'>
+  <front>
+    <title>Standard Specifications for Public Key Cryptography</title>
+    <author>
+      <organization>Institute of Electrical and Electronics Engineers</organization>
+    </author>
+    <date year='2000'/>
+  </front>
+</reference>


### PR DESCRIPTION
We don't have any variable length encoding after SM2 keys currently, format is instead identical to ECDSA. The main point of that seems to be to describe which hash to use for signatures/encryption. But that already exists as the "Preferred Hash Algorithms" list on the key, so I don't see why we'd need to repeat it as part of the key itself.

I changed RNP to include a hash id in the ciphertext 
in https://github.com/riboseinc/rnp/pull/446 instead of hardcoding SM3 there.